### PR TITLE
Add support for retrieving specific versions of credentials

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -1,6 +1,9 @@
 const AWS = require('aws-sdk');
 const async = require('async');
 const encoder = require('./encoder');
+if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
+}
 
 function decrypt(key, done) {
   var params = {

--- a/lib/secrets.js
+++ b/lib/secrets.js
@@ -1,5 +1,18 @@
 const AWS = require('aws-sdk');
 const async = require('async');
+const PAD_LEN = 19;
+if (typeof process.env.AWS_DEFAULT_REGION !== 'undefined') {
+  AWS.config.update({region: process.env.AWS_DEFAULT_REGION});
+}
+
+// Blatantly borrowed from https://www.electrictoolbox.com/pad-number-zeroes-javascript/
+function pad(number, length) {
+  var str = '' + number;
+  while (str.length < length) {
+    str = '0' + str;
+  }
+  return str;
+}
 
 function find(table, name, options, done) {
   var params = {
@@ -7,15 +20,33 @@ function find(table, name, options, done) {
     ConsistentRead: true,
     Limit: options.limit,
     ScanIndexForward: false,
-    KeyConditions: {
+  };
+  if (options.version !== 'undefined') {
+    params.KeyConditions = {
+      name: {
+        ComparisonOperator: 'EQ',
+        AttributeValueList: [{
+          S: name
+        }]
+      },
+      version: {
+        ComparisonOperator: 'EQ',
+        AttributeValueList: [{
+          S: pad(options.version, PAD_LEN)
+        }]
+      }
+    };
+  }
+  else {
+    param.KeyConditions = {
       name: {
         ComparisonOperator: 'EQ',
         AttributeValueList: [{
           S: name
         }]
       }
-    }
-  };
+    };
+  }
 
   return new AWS.DynamoDB().query(params, done);
 }


### PR DESCRIPTION
Suggested solution for
https://github.com/roylines/node-credstash/issues/9.

Using the available `options` construct and added an extra filter for
the DynamoDB column that Credstash uses to store version data.

Also added support for AWS region, as the JS SDK doesn't pull that by default from the environment. Makes development a bit easier.

Need to update test case scenarios (passing `{version: 1}` should be made somehow to work with mock).

I'm uncertain if this boggles any of the existing version handling logic (this is my first JS project).